### PR TITLE
Fixed display of commodity codes in commodity step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Pre-release
 
+
+### Implemented enhancements
+
 - TT-1865 - Add product search
 - no ticket - First user journey
 - no ticket - Add summary pages for flow A,C, and D
@@ -9,10 +12,8 @@
 - TT-1960 - Add extra validation to fields
 - TT-1954 - Use fonts provided by frontend toolkit
 - TT-1917 - Add print summary feature
-
-### Implemented enhancements
-
+- TT-1965 - Content change
 
 ### Bug fixes
 
-
+- TT-1992 - Fixed display of commodity codes in commodity step

--- a/core/templates/core/hierarchy-node-leaf.html
+++ b/core/templates/core/hierarchy-node-leaf.html
@@ -1,6 +1,6 @@
 <li id="{{ node.key }}" class="app-hierarchy-tree__part govuk-body app-hierarchy-tree__commodity">
 	<a href="#" class="app-hierarchy-tree__link app-hierarchy-tree__link--child">
-		<button name="wizard_select_product" value="{{ node.commodity_code.0 }} - {{node.label}}" type="submit" class="button-link button-link--leaf app-hierarchy-tree__link app-hierarchy-tree__link--child">	
+		<button name="wizard_select_product" value="{{ node.commodity_code|join:'' }} - {{node.label}}" type="submit" class="button-link button-link--leaf app-hierarchy-tree__link app-hierarchy-tree__link--child">
 			<span class="govuk-!-font-size-19">{{ node.label }}</span>
 			<span class="govuk-visually-hidden"> – </span>
 			<div class="app-hierarchy-button govuk-!-font-size-16">Select</div>

--- a/core/templates/core/wizard-step-product.html
+++ b/core/templates/core/wizard-step-product.html
@@ -60,7 +60,7 @@
             Select
           </button>
           {% else %}        
-            <a href="{% url view.url_name step='product-search' %}?node_id={{ result.node_id }}#{{ result.node_id }}" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold">Show in goods browser</a>
+            <a href="{% url view.url_name step='product-search' %}?node_id={{ result.node_id }}#{{ result.node_id }}" class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold">Expand to select</a>
           {% endif %}       
         </section>
         {% if not forloop.last %}


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] Change is accessible to the standards we subscribe to.
 - [x] Add a printscreen to the PR

![image](https://user-images.githubusercontent.com/5485798/66815965-2a158480-ef31-11e9-987e-6d6ff3027daf.png)

![image](https://user-images.githubusercontent.com/5485798/66816382-e7a07780-ef31-11e9-8be1-d14049f96ad7.png)

